### PR TITLE
Add functions to delete data > 24 hours & rework transfer functions

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -6,12 +6,14 @@ CREATE DATABASE plants;
 
 CREATE TABLE IF NOT EXISTS sun_condition (
    sun_condition_id INT GENERATED ALWAYS AS IDENTITY,
-   sun_condition_type TEXT NOT NULL UNIQUE
+   sun_condition_type TEXT NOT NULL UNIQUE,
+   PRIMARY KEY (sun_condition_id)
 );
 
 CREATE TABLE IF NOT EXISTS shade_condition (
    shade_condition_id INT GENERATED ALWAYS AS IDENTITY,
-   shade_condition_type TEXT NOT NULL UNIQUE
+   shade_condition_type TEXT NOT NULL UNIQUE,
+   PRIMARY KEY (shade_condition_id)
 );
 
 CREATE TABLE IF NOT EXISTS plant_origin (
@@ -72,12 +74,14 @@ CREATE SCHEMA long_term;
 
 CREATE TABLE IF NOT EXISTS long_term.sun_condition (
    sun_condition_id INT GENERATED ALWAYS AS IDENTITY,
-   sun_condition_type TEXT NOT NULL UNIQUE
+   sun_condition_type TEXT NOT NULL UNIQUE,
+   PRIMARY KEY (sun_condition_id)
 );
 
 CREATE TABLE IF NOT EXISTS long_term.shade_condition (
    shade_condition_id INT GENERATED ALWAYS AS IDENTITY,
    shade_condition_type TEXT NOT NULL UNIQUE
+   PRIMARY KEY (shade_condition_id)
 );
 
 CREATE TABLE IF NOT EXISTS long_term.plant_origin (
@@ -127,7 +131,5 @@ CREATE TABLE IF NOT EXISTS long_term.reading_information (
     PRIMARY KEY (reading_information_id),
     FOREIGN KEY (plant_id) REFERENCES plant(plant_id),
     FOREIGN KEY (botanist_id) REFERENCES botanist(botanist_id),
-    FOREIGN KEY (sun_condition_id) REFERENCES sun_condition(sun_condition_id),
-    FOREIGN KEY (shade_condition_id) REFERENCES shade_condition(shade_condition_id),
     CONSTRAINT unique_plant_reading_time UNIQUE (plant_id, plant_reading_time)
 );

--- a/schema.sql
+++ b/schema.sql
@@ -131,5 +131,7 @@ CREATE TABLE IF NOT EXISTS long_term.reading_information (
     PRIMARY KEY (reading_information_id),
     FOREIGN KEY (plant_id) REFERENCES plant(plant_id),
     FOREIGN KEY (botanist_id) REFERENCES botanist(botanist_id),
+    FOREIGN KEY (sun_condition_id) REFERENCES sun_condition(sun_condition_id),
+    FOREIGN KEY (shade_condition_id) REFERENCES shade_condition(shade_condition_id),
     CONSTRAINT unique_plant_reading_time UNIQUE (plant_id, plant_reading_time)
 );

--- a/schema.sql
+++ b/schema.sql
@@ -80,7 +80,7 @@ CREATE TABLE IF NOT EXISTS long_term.sun_condition (
 
 CREATE TABLE IF NOT EXISTS long_term.shade_condition (
    shade_condition_id INT GENERATED ALWAYS AS IDENTITY,
-   shade_condition_type TEXT NOT NULL UNIQUE
+   shade_condition_type TEXT NOT NULL UNIQUE,
    PRIMARY KEY (shade_condition_id)
 );
 

--- a/transfer_old_data.py
+++ b/transfer_old_data.py
@@ -81,11 +81,11 @@ def transfer_reading_information_table(conn: connection) -> None:
     cur = conn.cursor()
 
     cur.execute(f"""INSERT INTO long_term.reading_information
-                    (plant_id, plant_reading_time, botanist_id, soil_moisture, conditions, temperature)
-                    SELECT plant_id, plant_reading_time, botanist_id, soil_moisture, conditions, temperature 
+                    (plant_id, plant_reading_time, botanist_id, soil_moisture, sun_condition_id, shade_condition_id, temperature)
+                    SELECT plant_id, plant_reading_time, botanist_id, soil_moisture, sun_condition_id, shade_condition_id, temperature 
                     FROM reading_information
                     WHERE NOT EXISTS
-                    (SELECT plant_id, plant_reading_time, botanist_id, soil_moisture, conditions, temperature
+                    (SELECT plant_id, plant_reading_time, botanist_id, soil_moisture, sun_condition_id, shade_condition_id, temperature
                     FROM long_term.reading_information 
                     WHERE long_term.reading_information.plant_reading_time = reading_information.plant_reading_time);""")
 
@@ -94,8 +94,54 @@ def transfer_reading_information_table(conn: connection) -> None:
     print(data)
 
 
-# TODO COMPLETE
-def merge_plant_origin_table(conn: connection) -> None:
+# TODO Delete data or not?
+def transfer_shade_condition_table(conn: connection) -> None:
+    """
+    Transfers data in shade_condition from short_term to long_term schema
+    Will only transfer data that does not already exist in the long_term schema
+    """
+
+    cur = conn.cursor()
+
+    cur.execute(f"""INSERT INTO long_term.shade_condition
+                    (shade_condition_type)
+                    SELECT shade_condition_type 
+                    FROM shade_condition
+                    WHERE NOT EXISTS
+                    (SELECT shade_condition_type
+                    FROM long_term.shade_condition 
+                    WHERE long_term.shade_condition.shade_condition_type = shade_condition.shade_condition_type);""")
+
+    data = cur.fetchall()
+
+    print(data)
+
+
+# TODO Delete data or not?
+def transfer_sun_condition_table(conn: connection) -> None:
+    """
+    Transfers data in sun_condition from short_term to long_term schema
+    Will only transfer data that does not already exist in the long_term schema
+    """
+
+    cur = conn.cursor()
+
+    cur.execute(f"""INSERT INTO long_term.sun_condition
+                    (sun_condition_type)
+                    SELECT sun_condition_type 
+                    FROM sun_condition
+                    WHERE NOT EXISTS
+                    (SELECT sun_condition_type
+                    FROM long_term.sun_condition 
+                    WHERE long_term.sun_condition.sun_condition_type = sun_condition.sun_condition_type);""")
+
+    data = cur.fetchall()
+
+    print(data)
+
+
+# TODO Delete data or not?
+def transfer_plant_origin_table(conn: connection) -> None:
     """
     Transfers data in plant_origin from short_term to long_term schema
     Will only transfer data that does not already exist in the long_term schema
@@ -104,13 +150,15 @@ def merge_plant_origin_table(conn: connection) -> None:
     cur = conn.cursor()
 
     cur.execute(f"""INSERT INTO long_term.plant_origin
-                    CASE 
-                    WHEN latitude IS NaN THEN null
-                    WHEN longitude IS NAN THEN null
-                    SELECT * FROM plant_origin AS stpo
+                    (latitude, longitude, country)
+                    SELECT latitude, longitude, country 
+                    FROM plant_origin
                     WHERE NOT EXISTS
-                    (SELECT * FROM long_term.plant_origin 
-                    WHERE long_term.plant_origin.plant_origin_id = plant_origin.plant_origin_id);""")
+                    (SELECT latitude, longitude, country
+                    FROM long_term.plant_origin 
+                    WHERE long_term.plant_origin.latitude = plant_origin.latitude
+                    AND long_term.plant_origin.longitude = plant_origin.longitude
+                    AND long_term.plant_origin.country = plant_origin.country);""")
 
     data = cur.fetchall()
 
@@ -126,6 +174,5 @@ if __name__ == "__main__":
     conn = get_db_connection_lt(config)
 
     # merge_readings_table(conn)
-    merge_plant_origin_table(conn)
 
     conn.close()

--- a/transfer_old_data.py
+++ b/transfer_old_data.py
@@ -37,7 +37,10 @@ def transfer_botanist_table(conn: connection) -> None:
                     SELECT * FROM botanist AS stb
                     WHERE NOT EXISTS
                     (SELECT * FROM long_term.botanist
-                    WHERE long_term.botanist.botanist_phone_number = stb.botanist_phone_number);""")
+                    WHERE long_term.botanist.botanist_phone_number = botanist.botanist_phone_number
+                    AND long_term.botanist.botanist_name = botanist.botanist_name
+                    AND long_term.botanist.botanist_email = botanist.botanist_name
+                    AND long_term.botanist.botanist_id = botanist.botanist_id);""")
 
     commit_and_close_cursor(conn, cur)
 
@@ -54,7 +57,10 @@ def transfer_plant_table(conn: connection) -> None:
                     SELECT * FROM plant AS stp
                     WHERE NOT EXISTS
                     (SELECT * FROM long_term.plant 
-                     WHERE long_term.plant.plant_name = stp.plant_name);""")
+                    WHERE long_term.plant.plant_name = stp.plant_name
+                    AND long_term.plant.plant_scientific_name = stp.plant_scientific_name
+                    AND long_term.plant.plant_origin_id = stp.plant_origin_id
+                    AND long_term.plant.plant_id = stp.plant_id);""")
 
     cur.commit()
 


### PR DESCRIPTION
Function added to remove data that is older than 24 hours (in reading and last watered table specifically)
Some transfer functions reworked to account for "twin items" (will have the same values but different ids)
Fix syntax error in schema also